### PR TITLE
Adds ability to run one time and exit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ Usage:
 Flags:
   -h, --help                help for configmap-to-disk
       --key string          The ConfigMap key to read.
-      --kubeconfig string   Path to kubeconfig. (default "/home/squat/src/kubeconeu2020/kubeconfig")
+      --kubeconfig string   Path to kubeconfig. (default $KUBECONFIG)
       --listen string       The address at which to listen for health and metrics. (default ":8080")
       --log-level string    Log level to use. Possible values: all, debug, info, warn, error, none (default "info")
       --name string         The ConfigMap name.
       --namespace string    The namespace to watch.
+      --one-time            Syncs the configmap to disk a single time and exits.
       --path string         Where to write the file.
 ```

--- a/README.md
+++ b/README.md
@@ -82,6 +82,6 @@ Flags:
       --log-level string    Log level to use. Possible values: all, debug, info, warn, error, none (default "info")
       --name string         The ConfigMap name.
       --namespace string    The namespace to watch.
-      --one-time            Syncs the configmap to disk a single time and exits.
+      --one-time            Syncs the ConfigMap to disk a single time and exits.
       --path string         Where to write the file.
 ```

--- a/controller.go
+++ b/controller.go
@@ -57,7 +57,7 @@ func newController(client kubernetes.Interface, namespace, path, name, key strin
 }
 
 func (c *controller) run(stop <-chan struct{}) error {
-	c.client.CoreV1().ConfigMaps("namespace").Get("name", metav1.GetOptions{})
+
 	go c.informer.Run(stop)
 	if ok := cache.WaitForCacheSync(stop, func() bool {
 		return c.informer.HasSynced()

--- a/controller.go
+++ b/controller.go
@@ -111,7 +111,7 @@ func runOneTime(client kubernetes.Interface, namespace, path, name, key string, 
 
 	// Raise err if configmap doesn't exist
 	if err != nil {
-		level.Error(logger).Log("err", fmt.Sprintf("Failed to retrieve configmap: %v", err))
+		level.Error(logger).Log("err", fmt.Sprintf("Failed to retrieve ConfigMap: %v", err))
 		return err
 	}
 

--- a/controller.go
+++ b/controller.go
@@ -118,7 +118,7 @@ func runOneTime(client kubernetes.Interface, namespace, path, name, key string, 
 	// safe to file.
 	data, ok := cm.Data[key]
 	if !ok {
-		level.Error(logger).Log("err", fmt.Sprintf("Configmap does not have key: %v", key))
+		level.Error(logger).Log("err", fmt.Sprintf("ConfigMap does not have key: %v", key))
 		return fmt.Errorf("ConfigMap does not include specified key: %v", key)
 	}
 

--- a/controller.go
+++ b/controller.go
@@ -57,6 +57,7 @@ func newController(client kubernetes.Interface, namespace, path, name, key strin
 }
 
 func (c *controller) run(stop <-chan struct{}) error {
+	c.client.CoreV1().ConfigMaps("namespace").Get("name", metav1.GetOptions{})
 	go c.informer.Run(stop)
 	if ok := cache.WaitForCacheSync(stop, func() bool {
 		return c.informer.HasSynced()
@@ -103,4 +104,28 @@ func (c *controller) handle(obj interface{}) {
 		level.Error(c.logger).Log("err", fmt.Sprintf("failed to write file: %v", err))
 	}
 	return
+}
+
+func runOneTime(client kubernetes.Interface, namespace, path, name, key string, logger log.Logger) error {
+	// get configmap
+	cm, err := client.CoreV1().ConfigMaps(namespace).Get(name, metav1.GetOptions{})
+
+	// Raise err if configmap doesn't exist
+	if err != nil {
+		level.Error(logger).Log("err", fmt.Sprintf("Failed to retrieve configmap: %v", err))
+		return err
+	}
+
+	// safe to file.
+	data, ok := cm.Data[key]
+	if !ok {
+		level.Error(logger).Log("err", fmt.Sprintf("Configmap does not have key: %v", key))
+		return fmt.Errorf("Configmap does not include specified key: %v", key)
+	}
+
+	if err := ioutil.WriteFile(path, []byte(data), 0644); err != nil {
+		level.Error(logger).Log("err", fmt.Sprintf("failed to write file: %v", err))
+	}
+
+	return nil
 }

--- a/controller.go
+++ b/controller.go
@@ -119,7 +119,7 @@ func runOneTime(client kubernetes.Interface, namespace, path, name, key string, 
 	data, ok := cm.Data[key]
 	if !ok {
 		level.Error(logger).Log("err", fmt.Sprintf("Configmap does not have key: %v", key))
-		return fmt.Errorf("Configmap does not include specified key: %v", key)
+		return fmt.Errorf("ConfigMap does not include specified key: %v", key)
 	}
 
 	if err := ioutil.WriteFile(path, []byte(data), 0644); err != nil {

--- a/controller.go
+++ b/controller.go
@@ -57,7 +57,6 @@ func newController(client kubernetes.Interface, namespace, path, name, key strin
 }
 
 func (c *controller) run(stop <-chan struct{}) error {
-
 	go c.informer.Run(stop)
 	if ok := cache.WaitForCacheSync(stop, func() bool {
 		return c.informer.HasSynced()

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 	var logLevel string
 	cmd.PersistentFlags().StringVar(&logLevel, "log-level", logLevelInfo, fmt.Sprintf("Log level to use. Possible values: %s", availableLogLevels))
 	var syncOneTime bool
-	cmd.PersistentFlags().BoolVar(&syncOneTime, "one-time", false, "Syncs the configmap to disk a single time and exits.")
+	cmd.PersistentFlags().BoolVar(&syncOneTime, "one-time", false, "Syncs the ConfigMap to disk a single time and exits.")
 
 	var c kubernetes.Interface
 	var logger log.Logger

--- a/main.go
+++ b/main.go
@@ -90,6 +90,20 @@ func main() {
 		}
 		c = kubernetes.NewForConfigOrDie(config)
 
+		// Validate arguments are present
+		if len(namespace) == 0 {
+			return fmt.Errorf("Required argument not present: --namespace")
+		}
+		if len(key) == 0 {
+			return fmt.Errorf("Required argument not present: --key")
+		}
+		if len(path) == 0 {
+			return fmt.Errorf("Required argument not present: --path")
+		}
+		if len(name) == 0 {
+			return fmt.Errorf("Required argument not present: --name")
+		}
+
 		return nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -92,16 +92,16 @@ func main() {
 
 		// Validate arguments are present
 		if len(namespace) == 0 {
-			return fmt.Errorf("Required argument not present: --namespace")
+			return fmt.Errorf("required argument not present: --namespace")
 		}
 		if len(key) == 0 {
-			return fmt.Errorf("Required argument not present: --key")
+			return fmt.Errorf("required argument not present: --key")
 		}
 		if len(path) == 0 {
-			return fmt.Errorf("Required argument not present: --path")
+			return fmt.Errorf("required argument not present: --path")
 		}
 		if len(name) == 0 {
-			return fmt.Errorf("Required argument not present: --name")
+			return fmt.Errorf("required argument not present: --name")
 		}
 
 		// Determine whether to run once or run continuously. Default is continuous.

--- a/main.go
+++ b/main.go
@@ -104,14 +104,17 @@ func main() {
 			return fmt.Errorf("Required argument not present: --name")
 		}
 
+		// Determine whether to run once or run continuously. Default is continuous.
+		// Flags are only loaded in this context.
+		if syncOneTime {
+			cmd.RunE = runCmdOneTime(&c, &namespace, &path, &name, &key, &logger)
+		}
+
 		return nil
 	}
 
-	// Determine whether to run once or run continuously
-	if !syncOneTime {
-		cmd.RunE = runCmd(&c, &listen, &namespace, &path, &name, &key, &logger)
-	}
-	cmd.RunE = runCmdOneTime(&c, &namespace, &path, &name, &key, &logger)
+	// Default mode is continuous. This gets overwritten in PersistentPreRunE if the syncOneTime flag is enabled
+	cmd.RunE = runCmd(&c, &listen, &namespace, &path, &name, &key, &logger)
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ func main() {
 	if !syncOneTime {
 		cmd.RunE = runCmd(&c, &listen, &namespace, &path, &name, &key, &logger)
 	}
-	cmd.RunE = runOneTime(&c, &listen, &namespace, &path, &name, &key, &logger)
+	cmd.RunE = runCmdOneTime(&c, &namespace, &path, &name, &key, &logger)
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
@@ -154,15 +154,9 @@ func runCmd(c *kubernetes.Interface, listen, namespace, path, name, key *string,
 	}
 }
 
-func runOneTime(c *kubernetes.Interface, listen, namespace, path, name, key *string, logger *log.Logger) func(*cobra.Command, []string) error {
+func runCmdOneTime(c *kubernetes.Interface, namespace, path, name, key *string, logger *log.Logger) func(*cobra.Command, []string) error {
 	return func(_ *cobra.Command, args []string) error {
-		// get configmap
-		// handle configmap doesn't exist. error.
-		// safe to file.
-
 		level.Info(*logger).Log("msg", "Runing configmap-to-disk in one time mode.")
-
-		return nil
-
+		return runOneTime(*c, *namespace, *path, *name, *key, *logger)
 	}
 }


### PR DESCRIPTION
- Can be used to sync a configmap a single time and exit (for example as an initContainer). 
- Adds checks for some required params. 